### PR TITLE
fix(document): fix the incorrect type definitions and values

### DIFF
--- a/examples/simple-gateway/README.md
+++ b/examples/simple-gateway/README.md
@@ -40,7 +40,7 @@ No resource.
 | Name | Description | Value |
 |------|-------------|-------|
 | region_name | The region where the resources are located | `"cn-north-4"` |
-| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | "0" |
+| enterprise_project_id | Used to specify whether the resource is created under the enterprise project (this parameter is only valid for enterprise users) | `"0"` |
 | vpc_name | The name of the VPC resource | `"VPC-Test"` |
 | vpc_cidr | The CIDR block of the VPC resource | `"172.16.0.0/24"` |
 | subnets_configuration | The configuration for the subnet resources to which the VPC belongs | <pre>[<br>  {<br>    "name": "VPC-Subnet-Test",<br>    "cidr": "172.16.0.0/24",<br>    "ipv6_enabled": false,<br>    "dhcp_enabled": false<br>  }<br>]</pre> |

--- a/modules/vpn-connection/README.md
+++ b/modules/vpn-connection/README.md
@@ -52,12 +52,12 @@ No module.
 | connection_gateway_id | The ID of the VPN gateway used by the VPN connection | `string` | `""` | Y (Unless is_connection_create is specified as false) |
 | connection_gateway_ip | The IP address of the VPN gateway used by the VPN connection | `string` | `""` | Y (Unless is_connection_create is specified as false) |
 | connection_customer_gateway_id | The ID of the customer gateway used by the VPN connection | `string` | `""` | Y (Unless is_connection_create is specified as false) |
-| connection_vpn_type | The type of the VPN connection | `string` | "static" | N |
+| connection_vpn_type | The type of the VPN connection | `string` | `"static"` | N |
 | connection_pre_shared_key | The content of the pre-shared key | `string` | `""` | N |
-| connection_peer_subnets | The CIDR list of the customer subnets | <pre>list(string)</pre> | `""` | N |
+| connection_peer_subnets | The CIDR list of the customer subnets | <pre>list(string)</pre> | <pre>[]</pre> | N |
 | connection_tunnel_local_address | The local tunnel address of the VPN connection | `string` | `""` | N |
 | connection_tunnel_peer_address | The local peer address of the VPN connection | `string` | `""` | N |
-| connection_enable_nqa | Whether to enable NQA check for the VPN connection | `bool` | null | N |
+| connection_enable_nqa | Whether to enable NQA check for the VPN connection | `bool` | `null` | N |
 | connection_tags | The tags of the VPN connection | <pre>map(string)</pre> | <pre>{}</pre> | N |
 | connection_ha_role | The mode of the VPN connection | `string` | `""` | N |
 | connection_ikepolicy | The IKE policy of the VPN connection | <pre>list(object({<br>  authentication_algorithm = optional(string, null)<br>  encryption_algorithm     = optional(string, null)<br>  ike_version              = optional(string, null)<br>  lifetime_seconds         = optional(number, null)<br>  local_id_type            = optional(string, null)<br>  local_id                 = optional(string, null)<br>  peer_id_type             = optional(string, null)<br>  peer_id                  = optional(string, null)<br>  phase1_negotiation_mode  = optional(string, null)<br>  authentication_method    = optional(string, null)<br>  dh_group                 = optional(string, null)<br>  dpd                      = optional(list(object({<br>    timeout  = optional(number, null)<br>    interval = optional(number, null)<br>    msg      = optional(string, null)<br>  })), [])<br>}))</pre> | <pre>[]</pre> | N |

--- a/modules/vpn-customer-gateway/README.md
+++ b/modules/vpn-customer-gateway/README.md
@@ -49,9 +49,9 @@ No module.
 |------|-------------|------|:-------:|:--------:|
 | is_customer_gateway_create | Controls whether a VPN customer gateway should be created | `bool` | `true` | N |
 | customer_gateway_name | The name of the VPN gateway | `string` | `""` | Y (Unless is_customer_gateway_create is specified as false) |
-| customer_gateway_id_type | The identifier type of the VPN customer gateway | `string` | "ip" | Y |
+| customer_gateway_id_type | The identifier type of the VPN customer gateway | `string` | `"ip"` | Y |
 | customer_gateway_id_value | The identifier of the VPN customer gateway | `string` | `""` | Y (Unless is_customer_gateway_create is specified as false) |
-| customer_gateway_bgp_asn | The BGP ASN number of the VPN customer gateway | `number` | null | N |
+| customer_gateway_bgp_asn | The BGP ASN number of the VPN customer gateway | `number` | `null` | N |
 | customer_gateway_certificate_content | The CA certificate content of the VPN customer gateway | `string` | `""` | N |
 | customer_gateway_tags | The key/value pairs to associate with the VPN customer gateway | <pre>map(string)</pre> | <pre>{}</pre> | N |
 <!-- markdownlint-enable MD013 -->

--- a/modules/vpn-gateway/README.md
+++ b/modules/vpn-gateway/README.md
@@ -51,17 +51,17 @@ No module.
 | is_gateway_create | Controls whether a VPN should be created | `bool` | `true` | N |
 | gateway_name | The name of the VPN gateway | `string` | `""` | Y (Unless is_gateway_create is specified as false) |
 | gateway_availability_zones | The availability zones of the VPN gateway | <pre>list(string)</pre> | <pre>[]</pre> | Y (Unless is_gateway_create is specified as false) |
-| gateway_flavor | The flavor type of the VPN gateway | `string` | "Basic" | N |
-| gateway_attachment_type | The attachment type of the VPN gateway | `string` | "vpc" | N |
-| gateway_network_type | The network type of the VPN gateway | `string` | "public" | N |
+| gateway_flavor | The flavor type of the VPN gateway | `string` | `"Basic"` | N |
+| gateway_attachment_type | The attachment type of the VPN gateway | `string` | `"vpc"` | N |
+| gateway_network_type | The network type of the VPN gateway | `string` | `"public"` | N |
 | gateway_vpc_id | The ID of the VPC to which the VPN gateway is connected | `string` | `""` | N |
-| gateway_local_subnet_cidrs | The CIDR blocks that is in the VPC and needs to connect to the on-premises network through the VPN gateway | list(string) | <pre>[]</pre> | N |
+| gateway_local_subnet_cidrs | The CIDR blocks that is in the VPC and needs to connect to the on-premises network through the VPN gateway | <pre>list(string)</pre> | <pre>[]</pre> | N |
 | gateway_interconnection_subnet_id | The VPC subnet reserved for the P2C VPN gateway | `string` | `""` | N |
 | gateway_er_instance_id | The enterprise router ID to attach with the VPN gateway | `string` | `""` | N |
-| gateway_ha_mode | The HA mode of the VPN gateway | `string` | "active-active" | N |
-| gateway_bgp_asn | The BGP ASN number of the VPN gateway | `number` | null | N |
+| gateway_ha_mode | The HA mode of the VPN gateway | `string` | `"active-active"` | N |
+| gateway_bgp_asn | The BGP ASN number of the VPN gateway | `number` | `null` | N |
 | gateway_tags | The key/value pairs to associate with the VPN gateway | <pre>map(string)</pre> | <pre>{}</pre> | N |
-| delete_eip_on_termination | Whether to delete the EIP when the VPN gateway is deleted | `bool` | null | N |
+| delete_eip_on_termination | Whether to delete the EIP when the VPN gateway is deleted | `bool` | `null` | N |
 | gateway_access_vpc_id | The access VPC ID of the private VPN gateway | `string` | `""` | N |
 | gateway_access_subnet_id | The access subnet ID of the private VPN gateway | `string` | `""` | N |
 | gateway_access_private_ips | The access IP addresses of the private VPN gateway | `string` | `""` | N |


### PR DESCRIPTION
Fix the incorrect type definitions and values.
Each definition of the type  string, number, bool should be marked as the backtick (`), the values ditto.