### PR TITLE
fix(example): the data source difinitions are missing

### DIFF
--- a/examples/cross-region-connect/README.md
+++ b/examples/cross-region-connect/README.md
@@ -38,7 +38,10 @@ Run `terraform destroy` when you don't need these resources.
 
 ## Resources
 
-No resource.
+| Name | Type |
+|------|------|
+| data.huaweicloud_availability_zones.idc_center | data source |
+| data.huaweicloud_availability_zones.cloud_side | data source |
 
 ## Inputs
 

--- a/examples/simple-gateway/README.md
+++ b/examples/simple-gateway/README.md
@@ -32,7 +32,10 @@ Run `terraform destroy` when you don't need these resources.
 
 ## Resources
 
-No resource.
+| Name | Type |
+|------|------|
+| data.huaweicloud_availability_zones.this | data source |
+| data.huaweicloud_vpn_gateway_availability_zones.this | data source |
 
 ## Inputs
 


### PR DESCRIPTION
The resources part should be specified if the data sources are used.